### PR TITLE
Fix: Check resolved subscription against its status

### DIFF
--- a/src/Dashboard/Controllers/LandingPageController.cs
+++ b/src/Dashboard/Controllers/LandingPageController.cs
@@ -101,6 +101,7 @@ namespace Dashboard.Controllers
                                            cancellationToken);
 
             if (resolvedSubscription == default(ResolvedSubscription)) return default;
+            if (!resolvedSubscription.Success) return default;
 
             var existingSubscription = await this.fulfillmentClient.GetSubscriptionAsync(
                                            resolvedSubscription.SubscriptionId,


### PR DESCRIPTION
The ResolveSubscriptionAsync method returns a valid ResolvedSubscription object, which in case of failure will have the Success field set to false. The pre-existing check at line 103 wasn't enough and was resulting in a 500 if the subscription cannot be resolved.